### PR TITLE
Fixed Travis commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ docker-compose-Linux-x86_64
 venv
 __pycache__
 *.pyc
+national_voter_file.egg-info
+dist
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: python
 python:
      - "3.4"
      - "3.5"
-install: "pip install -r src/python/national_voter_file/tests/requirements.txt"
+install:
+  - pip install -r src/python/national_voter_file/tests/requirements.txt
+  - python setup.py install
 script: nosetests src/python/national_voter_file/tests


### PR DESCRIPTION
Travis wasn't installing the `national_voter_file` module itself, and `us_states` was missing an `__init__.py` file to be recognized as part of the package.