### PR TITLE
Yield nose tests functions so run separately

### DIFF
--- a/src/python/national_voter_file/tests/test_transformers.py
+++ b/src/python/national_voter_file/tests/test_transformers.py
@@ -59,4 +59,4 @@ def run_state_transformer(state_test):
 
 def test_all_transformers():
     for state_test in load_states(TEST_STATES):
-        run_state_transformer(state_test)
+        yield (run_state_transformer, state_test)


### PR DESCRIPTION
Quick update for convenience, yielding tests from nose apparently runs them as separate tests while still letting us keep it in one function. This way, we get a little more insight into which ones specifically are failing.