### PR TITLE
Fix Michigan zip loading, Pentaho ETL script

### DIFF
--- a/docker/buildMichigan.sh
+++ b/docker/buildMichigan.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+##################
+## Python script to clean up and enrich the Michigan Voter File
+docker-compose run etl python3 /national-voter-file/src/python/national_voter_file/transformers/csv_transformer.py -s mi -d /national-voter-file/data/Michigan/FOIA_Voters.zip -o /national-voter-file/data/Washington
+
+
+###################
+## Run job to process Michigan voter file
+docker-compose run etl /opt/pentaho/data-integration/kitchen.sh -file /national-voter-file/src/main/pdi/ProcessPreparedVoterFile.kjb -param:reportDate=2017-01-13 -param:reportFile=/national-voter-file/data/Michigan/mi_output.csv -param:reporterKey=4

--- a/src/python/national_voter_file/us_states/mi/transformer.py
+++ b/src/python/national_voter_file/us_states/mi/transformer.py
@@ -89,7 +89,10 @@ class StatePreparer(BasePreparer):
         with open(voter_file_path, 'r') as infile:
             for row in infile:
                 # Yield column with spaces stripped
-                yield [row[slice(*c)].strip() for c in self.col_indices]
+                yield dict(zip(
+                    self.transformer.input_fields,
+                    [row[slice(*c)].strip() for c in self.col_indices]
+                ))
 
     def voters(self, voter_file_path):
         reader = self.dict_iterator(self.open(self.input_path))


### PR DESCRIPTION
# What's in this PR?

* Fixed loading from zip file for `zip_voters`
* Added a `buildMichigan.sh` script as a shortcut for loading in MI data
