### PR TITLE
none for gender and party

### DIFF
--- a/src/python/national_voter_file/us_states/ok/transformer.py
+++ b/src/python/national_voter_file/us_states/ok/transformer.py
@@ -73,10 +73,10 @@ class StateTransformer(BaseTransformer):
     #### Demographics methods ##################################################
 
     def extract_gender(self, input_dict):
-        return {'GENDER': "U"}
+        return {'GENDER': None}
 
     def extract_race(self, input_dict):
-        return {'RACE': "U"}
+        return {'RACE': None}
 
     def extract_birth_state(self, input_columns):
         return {'BIRTH_STATE': None}


### PR DESCRIPTION
# What's in this PR?

Instead of a magic string which may change, use `None`

## References

Fixes #151 