### PR TITLE
Add pyenv's .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 build
 nohup.out
 docker/grasshopper-loader
+.python-version


### PR DESCRIPTION
# What's in this PR?

I am using pyenv to juggle python versions. It leaves a .python-version working dir in the project root, so it'd be helpful to have it in .gitignore.

