### PR TITLE
Colorado zip, gzip preparer, history handling

### DIFF
--- a/src/python/national_voter_file/us_states/mi/transformer.py
+++ b/src/python/national_voter_file/us_states/mi/transformer.py
@@ -2,7 +2,7 @@ import csv
 import os
 import re
 import sys
-import zipfile
+from zipfile import ZipFile
 from datetime import date
 
 from national_voter_file.transformers.base import (DATA_DIR,
@@ -107,13 +107,14 @@ class StatePreparer(BasePreparer):
         processing vote history, otherwise use simple row generator
         """
         if self.input_path.endswith('.zip'):
-            z = zipfile.ZipFile(self.input_path)
-            if self.history:
-                return self.yield_history_rows('entire_state_h.lst', zip_obj=z)
-            else:
-                return self.yield_zip_rows(z, 'entire_state_v.lst')
+            z = ZipFile(self.input_path)
         else:
             return self.yield_rows(self.input_path)
+
+        if self.history:
+            return self.yield_history_rows('entire_state_h.lst', zip_obj=z)
+        else:
+            return self.yield_zip_rows(z, 'entire_state_v.lst')
 
     def yield_rows(self, input_path):
         reader = csv.DictReader(self.open(input_path), delimiter=self.sep)


### PR DESCRIPTION
# What's in this PR?

* Zip and gzip handling added to CO preparer
* History handling added as well
* Fixes error in CO transformer around handling failed `usaddress` rows
* Cleans up formatting for Michigan zip transformer

Wanted to get in another example of how we can update the preparers so that voter files uploaded as zips in their original format could be processed without any additional manual cleanup. In this case, CO has multiple levels of nesting, so it would have to be for the subset of files.

## References
Progress on: #207 
