### PR TITLE
Created new db in postgres to hold API backing data

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -3,10 +3,6 @@ FROM mdillon/postgis:9.5
 ENV POSTGRES_DB VOTER
 
 RUN  mkdir /sql
-# COPY ../src/main/sql/clearDB.sql         /sql/
-# COPY ../src/main/sql/create_database.sql /sql/
-# COPY ../src/main/sql/create_tables.sql   /sql/
-# COPY ../src/main/sql/populate_static_data.sql /sql/
 COPY ./dockerResources/z-init-db.sh /docker-entrypoint-initdb.d/
 
 EXPOSE 5432

--- a/docker/postgis/dockerResources/z-init-db.sh
+++ b/docker/postgis/dockerResources/z-init-db.sh
@@ -3,3 +3,4 @@
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -a --dbname=VOTER < /sql/create_database.sql
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -a --dbname=VOTER < /sql/create_tables.sql
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -a --dbname=VOTER < /sql/populate_static_data.sql
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -a < /sql/create_api_database.sql

--- a/src/main/sql/create_api_database.sql
+++ b/src/main/sql/create_api_database.sql
@@ -1,0 +1,2 @@
+-- Create the api dev database
+CREATE DATABASE "NATIONAL_VOTER_FILE_API";


### PR DESCRIPTION
# What's in this PR?
Modified the postgres docker file to create a postgres logical database for api backing data.

1. Added a new script to the sql directory that creates the database
2. Invoked the new script in z-init-db.sh

We just needed this database to exist. Ecto will handle all of the rest of the setup.

## References

Progress on: 
[API Issue 22] (https://github.com/national-voter-file/national-voter-file-api/issues/22)
